### PR TITLE
AccountEventsNotificator to subscribe to traces instead of transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Telegram-Web-Apps/init-data-golang v1.1.1
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/go-faster/errors v0.6.1
 	github.com/go-faster/jx v1.1.0
@@ -15,8 +16,8 @@ require (
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/rs/cors v1.10.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tonkeeper/opentonapi v1.0.1-0.20230927063627-355a22c175b5
-	github.com/tonkeeper/tongo v1.3.1-0.20231004105015-243489c1eb93
+	github.com/tonkeeper/opentonapi v1.1.2-0.20231003160018-2a375104f6b7
+	github.com/tonkeeper/tongo v1.3.1-0.20231004110007-b929afe04f49
 	go.opentelemetry.io/otel v1.18.0
 	go.opentelemetry.io/otel/metric v1.18.0
 	go.opentelemetry.io/otel/trace v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -345,12 +347,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tonkeeper/opentonapi v1.0.1-0.20230927063627-355a22c175b5 h1:CPc8KPmTQs5/bEfaqGfYCgzN5YrZ541iRipuxHJu13w=
-github.com/tonkeeper/opentonapi v1.0.1-0.20230927063627-355a22c175b5/go.mod h1:9lHvDqAfbwtcUVcr/WBzpBqCo+MXnGpUbSLYiVOdwOY=
-github.com/tonkeeper/tongo v1.2.3-0.20230913212511-9b46bf078ec1 h1:0Bk19tz36nTJFrky7hNRXQFZ3BxWJOE2zuZM6UxnHUc=
-github.com/tonkeeper/tongo v1.2.3-0.20230913212511-9b46bf078ec1/go.mod h1:LdOBjpUz6vLp1EdX3E0XLNks9YI5XMSqaQahfOMrBEY=
-github.com/tonkeeper/tongo v1.3.1-0.20231004105015-243489c1eb93 h1:QFD69cj2exok592759zth6Cp1HoHNwbgp2sZW33Qbeg=
-github.com/tonkeeper/tongo v1.3.1-0.20231004105015-243489c1eb93/go.mod h1:LdOBjpUz6vLp1EdX3E0XLNks9YI5XMSqaQahfOMrBEY=
+github.com/tonkeeper/opentonapi v1.1.2-0.20231003160018-2a375104f6b7 h1:+nnV+MUw4g0O8X48k++tCXY8svFDf8DDAhWCz7GgEoM=
+github.com/tonkeeper/opentonapi v1.1.2-0.20231003160018-2a375104f6b7/go.mod h1:9lHvDqAfbwtcUVcr/WBzpBqCo+MXnGpUbSLYiVOdwOY=
+github.com/tonkeeper/tongo v1.3.1-0.20231004110007-b929afe04f49 h1:YNI0Z2Rjsgo9kWjTrLPHv6Pf6d1si2CO48kWld/Jvck=
+github.com/tonkeeper/tongo v1.3.1-0.20231004110007-b929afe04f49/go.mod h1:LdOBjpUz6vLp1EdX3E0XLNks9YI5XMSqaQahfOMrBEY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
The idea is to use https://tonapi.io/v2/sse/accounts/traces
to subscribe to completed traces. 
Once a trace is completed, we send notifications to all involved accounts.